### PR TITLE
 Security Fix: Use a trusted cryptographic random number generator.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/approximate/count/CountMinSketch.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/approximate/count/CountMinSketch.java
@@ -20,8 +20,8 @@ package org.wso2.extension.siddhi.execution.approximate.count;
 import org.wso2.extension.siddhi.execution.approximate.distinctcount.MurmurHash;
 
 import java.io.Serializable;
+import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Random;
 
 /**
  * A probabilistic data structure to keep count of different items.
@@ -74,7 +74,8 @@ public class CountMinSketch<E> implements Serializable {
 //      a,b are chosen independently for each hash function.
         this.hashCoefficientsA = new ArrayList<>(depth);
         this.hashCoefficientsB = new ArrayList<>(depth);
-        Random random = new Random(123);
+        SecureRandom random = new SecureRandom();
+        random.setSeed(123);
         for (int i = 0; i < depth; i++) {
             hashCoefficientsA.add(random.nextInt(Integer.MAX_VALUE));
             hashCoefficientsB.add(random.nextInt(Integer.MAX_VALUE));


### PR DESCRIPTION
## Purpose
> Standard random number generators do not provide a sufficient amount of entropy when used for security purposes.

## Goals
> Use a trusted cryptographic random number generator. 
